### PR TITLE
ChatSpaceのメッセージ自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -34,7 +34,7 @@ $(function(){
         scroll();
       })
       .fail(function() {
-        console.log('自動更新に失敗しました');
+        alert('自動更新に失敗しました');
       });
     }
   };

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,21 +1,44 @@
 $(function(){
   function buildHTML(message){
     var addImage = (message.image !== null) ? `<img class = "message__image", src="${message.image}">` : ``
-    var html = `<div class="message">
+    var html = `<div class="message" data-id=${message.id}>
                   <div class="message__upper-info">
                     <p class="message__upper-info__talker">${message.user_name}</p>
                     <p class="message__upper-info__date">${message.created_at}</p>
                   </div>
-                  <p class="message__text">
-                  ${message.text}
-                  </p>
-                  ${addImage}
-                <div>`
+                    <p class="message__text">${message.text}</p>
+                    ${addImage}
+                  <div>`
     return html;
-  }
+  };
+  
   function scroll(){
     $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
-  }
+  };
+  
+  var reloadMessages = function () {
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){
+      var last_message_id = $(".message").last().data("id");
+      $.ajax({
+        url: "api/messages",
+        type: 'GET',
+        dataType: 'json',
+        data: { id: last_message_id }
+      })
+      .done(function(messages) {
+        var insertHTML = "";
+        messages.forEach(function(message) {
+          insertHTML = buildHTML(message);
+          $('.messages').append(insertHTML);
+        })
+        scroll();
+      })
+      .fail(function() {
+        console.log('自動更新に失敗しました');
+      });
+    }
+  };
+  
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -39,5 +62,6 @@ $(function(){
       alert('error');
       $('.submit-btn').prop('disabled', false);
     })
-  })
+  });
+  setInterval(reloadMessages, 5000);
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.text message.text
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y/%m/%d(%a) %H:%M:%S")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{"data-id": "#{message.id}"}
   .message__upper-info
     %p.message__upper-info__talker<
       = message.user.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
## What
ChatSpaceにおけるメッセージの自動更新機能を実装する

## Why
メッセージの自動更新機能を実装することによって、非同期で新しいメッセージがあれば表示し自動でスライドされる。
これにより、利用者がページの開き直しや下までスライドさせる手間がなくなるため利便性が良くなる。